### PR TITLE
forward-port licenses from #78

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,3 +3,6 @@ REM since we are including it in the conda package separately, let's not do it w
 sed -i.bak '/^license =/d' pyproject.toml
 
 %PYTHON% -m pip install . -vv
+
+cd python
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -39,3 +39,5 @@ fi
 
 ${PYTHON} -m pip install . -vv
 
+cd python
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b3f896628876cc0465dccfb40cf76eaf977c6b551197e8e29da30f0457abb841
 
 build:
-  number: 0
+  number: 1
   # build failures on ppc64le
   skip: true                         # [ppc64le or (is_abi3 and not is_python_min)]
   python_version_independent: true   # [is_abi3]
@@ -21,6 +21,7 @@ requirements:
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - maturin >=1,<2
     - make
+    - cargo-bundle-licenses
     - {{ compiler('rust') }}
     - {{ compiler('c') }}  # [linux]
     - {{ stdlib("c") }}    # [linux]
@@ -56,7 +57,9 @@ about:
   home: https://github.com/delta-io/delta-rs
   summary: Native Delta Lake Python binding based on delta-rs with Pandas integration
   license: Apache-2.0
-  license_file: python/LICENSE.txt
+  license_file:
+    - python/LICENSE.txt
+    - python/THIRDPARTY.yml
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Thank again for maintaining this!

References:
- forward port from #78 

Changes:
- [x] get vendored `rust` licenses from `cargo-bundle-licenses`