### PR TITLE
remove pyarrow upper bound removed in 0.26 upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2e978950d420e050bbdcb5f62e3be93d331cb516ab4c9b1694cf1a7887c63e25
 
 build:
-  number: 1
+  number: 2
   # build failures on ppc64le
   skip: true  # [ppc64le or (is_abi3 and not is_python_min)]
   python_version_independent: true  # [is_abi3]
@@ -42,7 +42,7 @@ requirements:
     - deprecated >=1.2.18
     - pyarrow-hotfix
     - python
-    - pyarrow >=16,<19
+    - pyarrow >=16
 
 test:
   requires:


### PR DESCRIPTION
See https://github.com/delta-io/delta-rs/commit/a3c5299b3434e3442e5f22bbbed5257b02486d58

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
